### PR TITLE
Add Ruby 2.7 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,13 @@ Explore the interactive documentation live:
 
 ![Screenshot](https://a-chacon.com/assets/images/oas_rails_ui.png)
 
+## ✨ Key Features
+
+- **Dynamic Server Variables**: Configure server URLs with variables that users can customize directly in the documentation interface - perfect for multi-tenant applications where customers need to specify their subdomain or custom endpoints
+- **Automatic Documentation**: Generate interactive API documentation without additional DSLs or complex configurations
+- **Rails-Native**: Built specifically for Rails APIs using standard REST conventions
+- **Live Documentation**: Documentation updates automatically as your code changes
+
 ## Related Projects
 
 - **[ApiPie](https://github.com/Apipie/apipie-rails)**: Doesn't support OAS 3.1, requires learning a DSL, lacks a nice UI
@@ -36,6 +43,7 @@ Explore the interactive documentation live:
 - **Dynamic**: No command required to generate docs
 - **Simple**: Complement default documentation with a few comments; no need to learn a complex DSL
 - **Pure Ruby on Rails APIs**: No additional frameworks needed (e.g., Grape, RSpec)
+- **User-Friendly**: Server variables allow customers to test endpoints on their own domains/subdomains
 
 ## 📽️ Motivation
 

--- a/app/controllers/oas_rails/application_controller.rb
+++ b/app/controllers/oas_rails/application_controller.rb
@@ -1,5 +1,8 @@
 module OasRails
   class ApplicationController < ActionController::Base
     protect_from_forgery with: :exception
+
+    # Include the application helper to make favicon helper available
+    helper ApplicationHelper
   end
 end

--- a/app/controllers/oas_rails/oas_rails_controller.rb
+++ b/app/controllers/oas_rails/oas_rails_controller.rb
@@ -7,7 +7,7 @@ module OasRails
       respond_to do |format|
         format.html { render "index", layout: OasRails.config.layout }
         format.json do
-          render json: OasRails.build.to_json, status: :ok
+          render json: OasRails.build(request: request).to_json, status: :ok
         end
       end
     end

--- a/app/helpers/oas_rails/application_helper.rb
+++ b/app/helpers/oas_rails/application_helper.rb
@@ -1,4 +1,37 @@
 module OasRails
   module ApplicationHelper
+    def favicon_link_tag_for_oas_rails
+      return unless OasRails.config.info.favicon.present?
+
+      favicon_path = resolve_favicon_path(OasRails.config.info.favicon)
+      favicon_link_tag(favicon_path) if favicon_path
+    end
+
+    private
+
+    def resolve_favicon_path(favicon)
+      return nil if favicon.blank?
+
+      # If it's already a full URL (starts with http/https), return as-is
+      return favicon if favicon.match?(%r{\Ahttps?://})
+
+      # If it's a path starting with '/', treat as static asset in public/
+      return favicon if favicon.start_with?('/')
+
+      # Otherwise, try to resolve through asset pipeline using image_path
+      begin
+        # Use image_path which should work in both engine and application contexts
+        if respond_to?(:image_path)
+          image_path(favicon)
+        else
+          # Fallback: just return the original path
+          Rails.logger.warn("OasRails: image_path helper not available, using favicon path as-is: '#{favicon}'")
+          favicon
+        end
+      rescue StandardError => e
+        Rails.logger.warn("OasRails: Could not resolve favicon path '#{favicon}': #{e.message}")
+        favicon
+      end
+    end
   end
 end

--- a/app/views/layouts/oas_rails/application.html.erb
+++ b/app/views/layouts/oas_rails/application.html.erb
@@ -6,6 +6,7 @@
     <%= csp_meta_tag %>
     <meta charset="utf-8">
     <!-- Important: rapi-doc uses utf8 characters -->
+    <%= render 'oas_rails/shared/favicon' %>
   </head>
   <body>
     <%= yield %>

--- a/app/views/oas_rails/oas_rails/index.html.erb
+++ b/app/views/oas_rails/oas_rails/index.html.erb
@@ -6,6 +6,10 @@
     <%= csp_meta_tag %>
     <meta charset="utf-8">
     <!-- Important: rapi-doc uses utf8 characters -->
+    
+    <!-- Favicon -->
+    <%= render 'oas_rails/shared/favicon' %>
+    
     <script type="module" src="/oas-rails-assets/rapidoc-min.js"></script>
     <script>
       function applyTheme() {
@@ -22,8 +26,6 @@
         docEl.removeAttribute('nav-hover-text-color');
         docEl.removeAttribute('nav-accent-color');
         docEl.removeAttribute('primary-color');
-
-        console.log(theme === 'dark')
 
         if (theme === 'dark'){
           docEl.setAttribute('theme','dark');

--- a/app/views/oas_rails/shared/_favicon.html.erb
+++ b/app/views/oas_rails/shared/_favicon.html.erb
@@ -1,0 +1,12 @@
+<% if OasRails.config.info.favicon.present? %>
+  <% if respond_to?(:favicon_link_tag_for_oas_rails) %>
+    <%= favicon_link_tag_for_oas_rails %>
+  <% else %>
+    <!-- Fallback favicon handling -->
+    <% favicon_path = OasRails.config.info.favicon %>
+    <% unless favicon_path.match?(%r{\Ahttps?://}) || favicon_path.start_with?('/') %>
+      <% favicon_path = image_path(favicon_path) rescue OasRails.config.info.favicon %>
+    <% end %>
+    <%= favicon_link_tag(favicon_path) %>
+  <% end %>
+<% end %> 

--- a/docs/src/configuration/README.md
+++ b/docs/src/configuration/README.md
@@ -16,6 +16,13 @@ Then fill it with your data. Below are the available configuration options:
 
 - `config.info.description`: A detailed description of your API. This can include markdown formatting and will be displayed prominently in your documentation.
 
+- `config.info.favicon`: The favicon for your API documentation. This can be:
+  - An asset pipeline asset (e.g., `'favicon.ico'`, `'icons/custom-favicon.png'`)
+  - A static file in the public directory (e.g., `'/favicon.ico'`, `'/assets/favicon.png'`)
+  - A full URL (e.g., `'https://example.com/favicon.ico'`)
+  
+  The favicon will be automatically resolved at runtime, supporting assets with digests when using the asset pipeline.
+
 - `config.info.contact.name`: The name of the contact person or organization.
 
 - `config.info.contact.email`: The contact email address.

--- a/docs/src/configuration/README.md
+++ b/docs/src/configuration/README.md
@@ -31,7 +31,7 @@ Then fill it with your data. Below are the available configuration options:
   ```ruby
   config.servers = [
     { url: 'https://api.production.com', description: 'Production Server' },
-    { url: 'https://staging.api.com', description: 'Staging Server' },
+    { url: 'https://api.staging.com', description: 'Staging Server' },
     { url: 'http://localhost:3000', description: 'Development Server' }
   ]
   ```
@@ -43,7 +43,7 @@ Then fill it with your data. Below are the available configuration options:
     if Rails.env.production?
       [{ url: 'https://api.production.com', description: 'Production Server' }]
     elsif Rails.env.staging?
-      [{ url: 'https://staging.api.com', description: 'Staging Server' }]
+      [{ url: 'https://api.staging.com', description: 'Staging Server' }]
     else
       [{ url: 'http://localhost:3000', description: 'Development Server' }]
     end

--- a/docs/src/configuration/README.md
+++ b/docs/src/configuration/README.md
@@ -96,6 +96,97 @@ Then fill it with your data. Below are the available configuration options:
 
   For more details about server objects, refer to the [OpenAPI Specification](https://spec.openapis.org/oas/latest.html#server-object).
 
+#### Server Variables
+
+OasRails supports **server variables** following the OpenAPI 3.0+ specification, which allows users to customize server URLs directly in the documentation interface. This is particularly useful for multi-tenant applications or when users need to specify their own server endpoints.
+
+**Default Server Variables**: OasRails automatically includes a dynamic server with variables by default:
+
+```ruby
+# This server is included automatically in default_servers
+{
+  url: "https://{defaultHost}",
+  description: "Dynamic Server (enter your host)",
+  variables: {
+    defaultHost: {
+      default: "api.deployhq.com",
+      description: "Your server host (e.g., sg.deployhq.com for customer-specific endpoints)"
+    }
+  }
+}
+```
+
+**Custom Server Variables Configuration**: You can define servers with variables in any of the configuration methods:
+
+```ruby
+# Array configuration with server variables
+config.servers = [
+  {
+    url: "https://{environment}.api.{domain}",
+    description: "Environment and domain configurable API",
+    variables: {
+      environment: {
+        default: "staging",
+        enum: ["staging", "production"],
+        description: "API environment"
+      },
+      domain: {
+        default: "example.com",
+        description: "Your domain name"
+      }
+    }
+  }
+]
+```
+
+```ruby
+# Lambda configuration with server variables
+config.servers = -> {
+  [
+    {
+      url: "https://{customerHost}",
+      description: "Customer-specific API endpoint",
+      variables: {
+        customerHost: {
+          default: "api.yourcompany.com",
+          description: "Enter your customer-specific host (e.g., customer1.api.yourcompany.com)"
+        }
+      }
+    }
+  ]
+}
+```
+
+```ruby
+# Request-aware configuration with server variables
+config.servers = ->(request) {
+  base_host = request&.host || "localhost:3000"
+  [
+    {
+      url: "https://{subdomain}.#{base_host}",
+      description: "Multi-tenant API",
+      variables: {
+        subdomain: {
+          default: "api",
+          description: "Your tenant subdomain"
+        }
+      }
+    }
+  ]
+}
+```
+
+**Server Variable Properties**:
+- `default`: (Required) The default value for the variable
+- `enum`: (Optional) An array of valid values for the variable
+- `description`: (Optional) A description shown to users in the documentation interface
+
+This feature is especially useful for:
+- **Multi-tenant applications** where customers access different subdomains
+- **Environment selection** where users need to choose between staging/production
+- **Regional deployments** where users need to specify their region
+- **Customer-specific endpoints** where each customer has their own API host
+
 ### Tag Information
 
 - `config.tags`: An array of tag objects, each containing `name` and `description` keys. For more details, refer to the [OpenAPI Specification](https://spec.openapis.org/oas/latest.html#tag-object).

--- a/lib/generators/oas_rails/config/templates/oas_rails_initializer.rb
+++ b/lib/generators/oas_rails/config/templates/oas_rails_initializer.rb
@@ -43,6 +43,12 @@ OasRails.configure do |config|
   config.info.contact.email = 'andres.ch@proton.me'
   config.info.contact.url = 'https://a-chacon.com'
 
+  # Favicon for the documentation (optional)
+  # You can use an asset pipeline asset, a static file, or a full URL
+  # config.info.favicon = 'favicon.ico'                    # Asset pipeline asset
+  # config.info.favicon = '/favicon.ico'                   # Static file in public/
+  # config.info.favicon = 'https://example.com/icon.png'   # Full URL
+
   # Servers Information. For more details follow: https://spec.openapis.org/oas/latest.html#server-object
   # Static configuration: An array of server objects
   config.servers = [{ url: 'http://localhost:3000', description: 'Local' }]

--- a/lib/generators/oas_rails/config/templates/oas_rails_initializer.rb
+++ b/lib/generators/oas_rails/config/templates/oas_rails_initializer.rb
@@ -54,7 +54,7 @@ OasRails.configure do |config|
   #   if Rails.env.production?
   #     [{ url: 'https://api.production.com', description: 'Production Server' }]
   #   elsif Rails.env.staging?
-  #     [{ url: 'https://staging.api.com', description: 'Staging Server' }]
+  #     [{ url: 'https://api.staging.com', description: 'Staging Server' }]
   #   else
   #     [{ url: 'http://localhost:3000', description: 'Development Server' }]
   #   end

--- a/lib/generators/oas_rails/config/templates/oas_rails_initializer.rb
+++ b/lib/generators/oas_rails/config/templates/oas_rails_initializer.rb
@@ -44,7 +44,30 @@ OasRails.configure do |config|
   config.info.contact.url = 'https://a-chacon.com'
 
   # Servers Information. For more details follow: https://spec.openapis.org/oas/latest.html#server-object
+  # Static configuration: An array of server objects
   config.servers = [{ url: 'http://localhost:3000', description: 'Local' }]
+
+  # Dynamic configuration: Use a lambda/proc for runtime server definition
+  # Uncomment and modify the following example for dynamic servers based on environment:
+  #
+  # config.servers = -> {
+  #   if Rails.env.production?
+  #     [{ url: 'https://api.production.com', description: 'Production Server' }]
+  #   elsif Rails.env.staging?
+  #     [{ url: 'https://staging.api.com', description: 'Staging Server' }]
+  #   else
+  #     [{ url: 'http://localhost:3000', description: 'Development Server' }]
+  #   end
+  # }
+  #
+  # Request-aware configuration: Use request context for multi-tenant or dynamic routing
+  # config.servers = ->(request) {
+  #   if request && request.subdomain.present?
+  #     [{ url: "https://#{request.subdomain}.api.yourdomain.com", description: "#{request.subdomain.capitalize} API" }]
+  #   else
+  #     [{ url: 'https://api.yourdomain.com', description: 'Main API' }]
+  #   end
+  # }
 
   # Tag Information. For more details follow: https://spec.openapis.org/oas/latest.html#tag-object
   config.tags = [{ name: "Users", description: "Manage the `amazing` Users table." }]

--- a/lib/oas_rails.rb
+++ b/lib/oas_rails.rb
@@ -42,6 +42,7 @@ module OasRails
     autoload :Contact, "oas_rails/spec/contact"
     autoload :Info, "oas_rails/spec/info"
     autoload :Server, "oas_rails/spec/server"
+    autoload :ServerVariable, "oas_rails/spec/server_variable"
     autoload :Tag, "oas_rails/spec/tag"
     autoload :Specification, "oas_rails/spec/specification"
     autoload :Reference, "oas_rails/spec/reference"

--- a/lib/oas_rails.rb
+++ b/lib/oas_rails.rb
@@ -64,8 +64,8 @@ module OasRails
   end
 
   class << self
-    def build
-      oas = Spec::Specification.new
+    def build(request: nil)
+      oas = Spec::Specification.new(request: request)
       oas.build
 
       oas.to_spec

--- a/lib/oas_rails/active_record_example_finder.rb
+++ b/lib/oas_rails/active_record_example_finder.rb
@@ -36,8 +36,7 @@ module OasRails
         @factory_examples[klass_sym].each_with_index.to_h do |obj, index|
           ["#{klass_sym}#{index + 1}", { value: { klass_sym => clean_example_object(obj: obj.as_json) } }]
         end.deep_symbolize_keys
-      rescue KeyError, NameError => e
-        Rails.logger.debug("Factory not found for #{klass_sym}: #{e.message}") if defined?(Rails) && Rails.logger
+      rescue KeyError, NameError => _e
         {}
       end
     end

--- a/lib/oas_rails/active_record_example_finder.rb
+++ b/lib/oas_rails/active_record_example_finder.rb
@@ -1,9 +1,9 @@
 module OasRails
   class ActiveRecordExampleFinder
-    def initialize(context: :incoming, utils: Utils, factory_bot: FactoryBot, erb: ERB, yaml: YAML, file: File)
+    def initialize(context: :incoming, utils: Utils, factory_bot: nil, erb: ERB, yaml: YAML, file: File)
       @context = context
       @utils = utils
-      @factory_bot = factory_bot
+      @factory_bot = factory_bot || (defined?(FactoryBot) ? FactoryBot : nil)
       @erb = erb
       @yaml = yaml
       @file = file
@@ -26,6 +26,8 @@ module OasRails
     # @param klass [Class] the class to fetch examples for.
     # @return [Hash] a hash containing examples data or an empty hash if no examples are found.
     def fetch_factory_bot_examples(klass:)
+      return {} unless @factory_bot
+      
       klass_sym = @utils.class_to_symbol(klass)
 
       begin
@@ -34,7 +36,8 @@ module OasRails
         @factory_examples[klass_sym].each_with_index.to_h do |obj, index|
           ["#{klass_sym}#{index + 1}", { value: { klass_sym => clean_example_object(obj: obj.as_json) } }]
         end.deep_symbolize_keys
-      rescue KeyError
+      rescue KeyError, NameError => e
+        Rails.logger.debug("Factory not found for #{klass_sym}: #{e.message}") if defined?(Rails) && Rails.logger
         {}
       end
     end

--- a/lib/oas_rails/builders/content_builder.rb
+++ b/lib/oas_rails/builders/content_builder.rb
@@ -35,7 +35,7 @@ module OasRails
       def from_model_class(klass)
         return self unless Utils.active_record_class?(klass)
 
-        model_schema = Builders::EsquemaBuilder.send("build_#{@context}_schema", klass:)
+        model_schema = Builders::EsquemaBuilder.send("build_#{@context}_schema", klass: klass)
         model_schema["required"] = []
         schema = { type: "object", properties: { klass.to_s.downcase => model_schema } }
         examples = ActiveRecordExampleFinder.new(context: @context).search(klass)

--- a/lib/oas_rails/builders/esquema_builder.rb
+++ b/lib/oas_rails/builders/esquema_builder.rb
@@ -18,8 +18,11 @@ module OasRails
         # Builds a schema for a class when it is used as outgoing API data.
         #
         # @param klass [Class] The class for which the schema is built.
+        # @param klass_method [String, Symbol, nil] Optional method to call on the class.
+        # @param model_to_schema_class [Class] The schema builder class.
         # @return [Hash] The schema as a JSON-compatible hash.
-        def build_outgoing_schema(klass:, model_to_schema_class: EasyTalk)
+        def build_outgoing_schema(klass:, klass_method: nil, model_to_schema_class: EasyTalk)
+          return klass.public_send(klass_method) if klass_method.present? && klass.respond_to?(klass_method)
           return klass.api_hash_schema if klass.respond_to?(:api_hash_schema)
 
           build_schema(

--- a/lib/oas_rails/builders/esquema_builder.rb
+++ b/lib/oas_rails/builders/esquema_builder.rb
@@ -20,22 +20,14 @@ module OasRails
         # @param klass [Class] The class for which the schema is built.
         # @return [Hash] The schema as a JSON-compatible hash.
         def build_outgoing_schema(klass:, model_to_schema_class: EasyTalk)
-          if klass.respond_to?(:api_hash_schema)
-            Rails.logger.debug("[#{klass}] Using custom schema.")
-            Rails.logger.debug("[#{klass}] Schema: #{klass.api_hash_schema}")
-            return klass.api_hash_schema
-          end
+          return klass.api_hash_schema if klass.respond_to?(:api_hash_schema)
 
-          schema = build_schema(
+          build_schema(
             klass: klass,
             model_to_schema_class: model_to_schema_class,
             excluded_columns: OasRails.config.excluded_columns_outgoing,
             exclude_primary_key: false
           )
-
-          Rails.logger.debug("[#{klass}] Generated schema: #{schema}")
-
-          schema
         end
 
         private

--- a/lib/oas_rails/builders/esquema_builder.rb
+++ b/lib/oas_rails/builders/esquema_builder.rb
@@ -20,6 +20,8 @@ module OasRails
         # @param klass [Class] The class for which the schema is built.
         # @return [Hash] The schema as a JSON-compatible hash.
         def build_outgoing_schema(klass:, model_to_schema_class: EasyTalk)
+          return klass::API_HASH_SCHEMA if klass.const_defined?(:API_HASH_SCHEMA)
+
           build_schema(
             klass: klass,
             model_to_schema_class: model_to_schema_class,

--- a/lib/oas_rails/builders/esquema_builder.rb
+++ b/lib/oas_rails/builders/esquema_builder.rb
@@ -20,8 +20,6 @@ module OasRails
         # @param klass [Class] The class for which the schema is built.
         # @return [Hash] The schema as a JSON-compatible hash.
         def build_outgoing_schema(klass:, model_to_schema_class: EasyTalk)
-          return klass::API_HASH_SCHEMA if klass.const_defined?(:API_HASH_SCHEMA)
-
           build_schema(
             klass: klass,
             model_to_schema_class: model_to_schema_class,

--- a/lib/oas_rails/builders/esquema_builder.rb
+++ b/lib/oas_rails/builders/esquema_builder.rb
@@ -20,12 +20,22 @@ module OasRails
         # @param klass [Class] The class for which the schema is built.
         # @return [Hash] The schema as a JSON-compatible hash.
         def build_outgoing_schema(klass:, model_to_schema_class: EasyTalk)
-          build_schema(
+          if klass.respond_to?(:api_hash_schema)
+            Rails.logger.debug("[#{klass}] Using custom schema.")
+            Rails.logger.debug("[#{klass}] Schema: #{klass.api_hash_schema}")
+            return klass.api_hash_schema
+          end
+
+          schema = build_schema(
             klass: klass,
             model_to_schema_class: model_to_schema_class,
             excluded_columns: OasRails.config.excluded_columns_outgoing,
             exclude_primary_key: false
           )
+
+          Rails.logger.debug("[#{klass}] Generated schema: #{schema}")
+
+          schema
         end
 
         private

--- a/lib/oas_rails/builders/oas_route_builder.rb
+++ b/lib/oas_rails/builders/oas_route_builder.rb
@@ -75,29 +75,23 @@ module OasRails
         method_comment = controller_class.constantize.instance_method(method).comment
         class_comment = extract_class_comment(controller_class.constantize)
 
+        Rails.logger.debug("[#{method}] Method comment: #{method_comment}")
+
         method_tags = parse_tags(method_comment)
         class_tags = parse_tags(class_comment)
+
+        Rails.logger.debug("[#{method}] Method tags: #{method_tags.inspect}")
+        Rails.logger.debug("[#{method}] Class tags: #{class_tags.inspect}")
 
         method_tags + class_tags
       end
 
       def extract_class_comment(klass)
-        # Ruby 2.7 compatible way to get class comments
-        # Get the file path where the class is defined
-        file_path = klass.instance_method(method).source_location.first
-        return "" unless file_path && File.exist?(file_path)
-      
-        # Read the file and extract comments above the class definition
-        file_content = File.read(file_path)
-        class_name = klass.name.split("::").last
-        if (match = file_content.match(/^\s*#\s*(.*?)\s*class\s+#{class_name}/m))
-          match[1].to_s
-        else
-          ""
-        end
-      rescue StandardError => e
-        Rails.logger.warn("Failed to extract class comment: #{e.message}") if defined?(Rails) && Rails.logger
-        ""
+        instance_method = klass.instance_method(method)
+        return instance_method.class_comment if instance_method.respond_to?(:class_comment)
+
+        # Ruby 2.7 compatibility fallback
+        ''
       end
 
       def parse_tags(comment)

--- a/lib/oas_rails/builders/oas_route_builder.rb
+++ b/lib/oas_rails/builders/oas_route_builder.rb
@@ -57,6 +57,8 @@ module OasRails
 
       def source_string
         controller_class.constantize.instance_method(method).source
+      rescue ::MethodSource::SourceNotFoundError => _e
+        ''
       end
 
       def docstring

--- a/lib/oas_rails/builders/oas_route_builder.rb
+++ b/lib/oas_rails/builders/oas_route_builder.rb
@@ -58,6 +58,7 @@ module OasRails
       def source_string
         controller_class.constantize.instance_method(method).source
       rescue ::MethodSource::SourceNotFoundError => _e
+        # Handle dynamically defined methods or methods without source - we just ignore them for now
         ''
       end
 
@@ -77,13 +78,8 @@ module OasRails
         method_comment = controller_class.constantize.instance_method(method).comment
         class_comment = extract_class_comment(controller_class.constantize)
 
-        Rails.logger.debug("[#{method}] Method comment: #{method_comment}")
-
         method_tags = parse_tags(method_comment)
         class_tags = parse_tags(class_comment)
-
-        Rails.logger.debug("[#{method}] Method tags: #{method_tags.inspect}")
-        Rails.logger.debug("[#{method}] Class tags: #{class_tags.inspect}")
 
         method_tags + class_tags
       end
@@ -92,7 +88,7 @@ module OasRails
         instance_method = klass.instance_method(method)
         return instance_method.class_comment if instance_method.respond_to?(:class_comment)
 
-        # Ruby 2.7 compatibility fallback
+        # Ruby 2.7 compatibility fallback (ignore class comment if not available)
         ''
       end
 

--- a/lib/oas_rails/builders/operation_builder.rb
+++ b/lib/oas_rails/builders/operation_builder.rb
@@ -9,11 +9,11 @@ module OasRails
       end
 
       def from_oas_route(oas_route)
-        @operation.summary = extract_summary(oas_route:)
-        @operation.operation_id = extract_operation_id(oas_route:)
+        @operation.summary = extract_summary(oas_route: oas_route)
+        @operation.operation_id = extract_operation_id(oas_route: oas_route)
         @operation.description = oas_route.docstring
-        @operation.tags = extract_tags(oas_route:)
-        @operation.security = extract_security(oas_route:)
+        @operation.tags = extract_tags(oas_route: oas_route)
+        @operation.security = extract_security(oas_route: oas_route)
         @operation.parameters = ParametersBuilder.new(@specification).from_oas_route(oas_route).build
         @operation.request_body = RequestBodyBuilder.new(@specification).from_oas_route(oas_route).reference
         @operation.responses = ResponsesBuilder.new(@specification)

--- a/lib/oas_rails/builders/request_body_builder.rb
+++ b/lib/oas_rails/builders/request_body_builder.rb
@@ -19,7 +19,7 @@ module OasRails
 
       def from_tags(tag:, examples_tags: [])
         if Utils.active_record_class?(tag.klass)
-          from_model_class(klass: tag.klass, description: tag.text, required: tag.required, examples_tags:)
+          from_model_class(klass: tag.klass, description: tag.text, required: tag.required, examples_tags: examples_tags)
         else
           @request_body.description = tag.text
           @request_body.content = ContentBuilder.new(@specification, :incoming).with_schema(tag.schema).with_examples_from_tags(examples_tags).build
@@ -54,7 +54,7 @@ module OasRails
       def detect_request_body(oas_route)
         return unless (klass = Utils.find_model_from_route(oas_route.controller))
 
-        from_model_class(klass:, required: true)
+        from_model_class(klass: klass, required: true)
       end
     end
   end

--- a/lib/oas_rails/configuration.rb
+++ b/lib/oas_rails/configuration.rb
@@ -63,7 +63,19 @@ module OasRails
     end
 
     def default_servers
-      [Spec::Server.new(url: "http://localhost:3000", description: "Rails Default Development Server")]
+      [
+        Spec::Server.new(url: "http://localhost:3000", description: "Rails Default Development Server"),
+        Spec::Server.new(
+          url: "https://{defaultHost}",
+          description: "Dynamic Server (enter your host)",
+          variables: {
+            defaultHost: {
+              default: "api.domain.com",
+              description: "Your server host (e.g., api.domain.com)"
+            }
+          }
+        )
+      ]
     end
 
     def servers=(value)
@@ -72,7 +84,13 @@ module OasRails
         @servers_proc = value
         @servers_static = nil
       when Array
-        @servers_static = value.map { |s| Spec::Server.new(url: s[:url], description: s[:description]) }
+        @servers_static = value.map do |s|
+          Spec::Server.new(
+            url: s[:url],
+            description: s[:description],
+            variables: s[:variables]
+          )
+        end
         @servers_proc = nil
       else
         raise ArgumentError, "servers must be an Array or a Proc"
@@ -89,7 +107,13 @@ module OasRails
                       end
         case proc_result
         when Array
-          proc_result.map { |s| Spec::Server.new(url: s[:url], description: s[:description]) }
+          proc_result.map do |s|
+            Spec::Server.new(
+              url: s[:url],
+              description: s[:description],
+              variables: s[:variables]
+            )
+          end
         else
           raise ArgumentError, "servers proc must return an Array"
         end

--- a/lib/oas_rails/configuration.rb
+++ b/lib/oas_rails/configuration.rb
@@ -15,7 +15,7 @@ module OasRails
                   :use_model_names,
                   :rapidoc_theme
 
-    attr_reader :servers, :tags, :security_schema, :include_mode, :response_body_of_default
+    attr_reader :tags, :security_schema, :include_mode, :response_body_of_default
 
     def initialize
       @info = Spec::Info.new
@@ -67,7 +67,37 @@ module OasRails
     end
 
     def servers=(value)
-      @servers = value.map { |s| Spec::Server.new(url: s[:url], description: s[:description]) }
+      case value
+      when Proc
+        @servers_proc = value
+        @servers_static = nil
+      when Array
+        @servers_static = value.map { |s| Spec::Server.new(url: s[:url], description: s[:description]) }
+        @servers_proc = nil
+      else
+        raise ArgumentError, "servers must be an Array or a Proc"
+      end
+    end
+
+    def servers(request = nil)
+      if @servers_proc
+        # Evaluate the proc and convert the result to Server objects
+        proc_result = if @servers_proc.arity > 0
+                        @servers_proc.call(request)
+                      else
+                        @servers_proc.call
+                      end
+        case proc_result
+        when Array
+          proc_result.map { |s| Spec::Server.new(url: s[:url], description: s[:description]) }
+        else
+          raise ArgumentError, "servers proc must return an Array"
+        end
+      elsif @servers_static
+        @servers_static
+      else
+        default_servers
+      end
     end
 
     def tags=(value)

--- a/lib/oas_rails/extractors/oas_route_extractor.rb
+++ b/lib/oas_rails/extractors/oas_route_extractor.rb
@@ -12,7 +12,7 @@ module OasRails
       def extract_tags(oas_route:)
         tags = oas_route.tags(:tags).first
         if tags.nil?
-          default_tags(oas_route:)
+          default_tags(oas_route: oas_route)
         else
           tags.text.split(",").map(&:strip).map(&:titleize)
         end

--- a/lib/oas_rails/extractors/render_response_extractor.rb
+++ b/lib/oas_rails/extractors/render_response_extractor.rb
@@ -61,7 +61,7 @@ module OasRails
           klass = maybe_a_model.singularize.camelize(:upper).constantize
 
           if Utils.active_record_class?(klass)
-            schema = Builders::EsquemaBuilder.build_outgoing_schema(klass:)
+            schema = Builders::EsquemaBuilder.build_outgoing_schema(klass: klass)
             if test_singularity(maybe_a_model)
               build_singular_model_schema_and_examples(maybe_a_model, errors, klass, schema)
             else

--- a/lib/oas_rails/json_schema_generator.rb
+++ b/lib/oas_rails/json_schema_generator.rb
@@ -26,13 +26,13 @@ module OasRails
 
       case type
       when /^Hash\{(.+)\}$/i
-        { type: :object, required:, properties: parse_object_properties(::Regexp.last_match(1)) }
+        { type: :object, required: required, properties: parse_object_properties(::Regexp.last_match(1)) }
       when /^Array<(.+)>$/i
-        { type: :array, required:, items: parse_type(::Regexp.last_match(1)) }
+        { type: :array, required: required, items: parse_type(::Regexp.last_match(1)) }
       when ->(t) { Utils.active_record_class?(t) }
         Builders::EsquemaBuilder.build_outgoing_schema(klass: type.constantize)
       else
-        { type: type.downcase.to_sym, required: }
+        { type: type.downcase.to_sym, required: required }
       end
     end
 

--- a/lib/oas_rails/json_schema_generator.rb
+++ b/lib/oas_rails/json_schema_generator.rb
@@ -29,8 +29,11 @@ module OasRails
         { type: :object, required: required, properties: parse_object_properties(::Regexp.last_match(1)) }
       when /^Array<(.+)>$/i
         { type: :array, required: required, items: parse_type(::Regexp.last_match(1)) }
+      when ->(t) { t&.include?('.') }
+        klass, klass_method = type.split('.')
+        Builders::EsquemaBuilder.build_outgoing_schema(klass: klass.constantize, klass_method: klass_method)
       when ->(t) { Utils.active_record_class?(t) }
-        Builders::EsquemaBuilder.build_outgoing_schema(klass: type.constantize)
+        Builders::EsquemaBuilder.build_outgoing_schema(klass: type.constantize, klass_method: :api_hash_schema)
       else
         { type: type.downcase.to_sym, required: required }
       end

--- a/lib/oas_rails/spec/info.rb
+++ b/lib/oas_rails/spec/info.rb
@@ -2,7 +2,7 @@ module OasRails
   module Spec
     class Info
       include Specable
-      attr_accessor :title, :summary, :description, :terms_of_service, :contact, :license, :version
+      attr_accessor :title, :summary, :description, :terms_of_service, :contact, :license, :version, :favicon
 
       def initialize(**kwargs)
         @title = kwargs[:title] || default_title
@@ -12,10 +12,11 @@ module OasRails
         @contact = Spec::Contact.new
         @license = Spec::License.new
         @version = kwargs[:version] || '0.0.1'
+        @favicon = kwargs[:favicon] || nil
       end
 
       def oas_fields
-        [:title, :summary, :description, :terms_of_service, :contact, :license, :version]
+        [:title, :summary, :description, :terms_of_service, :contact, :license, :version, :favicon]
       end
 
       def default_title

--- a/lib/oas_rails/spec/server.rb
+++ b/lib/oas_rails/spec/server.rb
@@ -2,15 +2,36 @@ module OasRails
   module Spec
     class Server
       include Specable
-      attr_accessor :url, :description
+      attr_accessor :url, :description, :variables
 
-      def initialize(url:, description:)
+      def initialize(url:, description:, variables: nil)
         @url = url
         @description = description
+        @variables = process_variables(variables)
       end
 
       def oas_fields
-        [:url, :description]
+        [:url, :description, :variables]
+      end
+
+      private
+
+      def process_variables(variables)
+        return nil if variables.nil? || variables.empty?
+
+        processed = {}
+        variables.each do |key, value|
+          processed[key] = if value.is_a?(Hash)
+                             ServerVariable.new(
+                               default: value[:default] || value['default'],
+                               enum: value[:enum] || value['enum'],
+                               description: value[:description] || value['description']
+                             )
+                           else
+                             value
+                           end
+        end
+        processed
       end
     end
   end

--- a/lib/oas_rails/spec/server_variable.rb
+++ b/lib/oas_rails/spec/server_variable.rb
@@ -1,0 +1,18 @@
+module OasRails
+  module Spec
+    class ServerVariable
+      include Specable
+      attr_accessor :default, :enum, :description
+
+      def initialize(default:, enum: nil, description: nil)
+        @default = default
+        @enum = enum
+        @description = description
+      end
+
+      def oas_fields
+        [:default, :enum, :description]
+      end
+    end
+  end
+end

--- a/lib/oas_rails/spec/specable.rb
+++ b/lib/oas_rails/spec/specable.rb
@@ -17,12 +17,16 @@ module OasRails
                               value.to_spec
                             elsif value.is_a?(Array) && value.all? { |elem| elem.respond_to?(:to_spec) }
                               value.map(&:to_spec)
-                            # elsif value.is_a?(Hash)
-                            #   hash = {}
-                            #   value.each do |key, object|
-                            #     hash[key] = object.to_spec
-                            #   end
-                            #   hash
+                            elsif value.is_a?(Hash)
+                              processed_hash = {}
+                              value.each do |hash_key, object|
+                                processed_hash[hash_key] = if object.respond_to?(:to_spec)
+                                                             object.to_spec
+                                                           else
+                                                             object
+                                                           end
+                              end
+                              processed_hash
                             else
                               value
                             end

--- a/lib/oas_rails/spec/specification.rb
+++ b/lib/oas_rails/spec/specification.rb
@@ -30,7 +30,15 @@ module OasRails
       #
       # @return [void]
       def clear_cache
-        # MethodSource.clear_cache # is not available in Ruby 2.7
+        if defined?(MethodSource)
+          if MethodSource.respond_to?(:clear_cache)
+            MethodSource.clear_cache
+          else
+            # Ruby 2.7 support
+            MethodSource.instance_variable_set(:@source_cache, {})
+          end
+        end
+
         Extractors::RouteExtractor.clear_cache
       end
 

--- a/lib/oas_rails/spec/specification.rb
+++ b/lib/oas_rails/spec/specification.rb
@@ -4,20 +4,26 @@ module OasRails
   module Spec
     class Specification
       include Specable
-      attr_accessor :components, :info, :openapi, :servers, :tags, :external_docs, :paths
+      attr_accessor :components, :info, :openapi, :tags, :external_docs, :paths
+      attr_reader :request
 
       # Initializes a new Specification object.
       # Clears the cache if running in the development environment.
-      def initialize
+      def initialize(request: nil)
+        @request = request
         clear_cache unless Rails.env.production?
 
         @components = Components.new(self)
         @info = OasRails.config.info
         @openapi = '3.1.0'
-        @servers = OasRails.config.servers
         @tags = OasRails.config.tags
         @external_docs = {}
         @paths = Spec::Paths.new(self)
+      end
+
+      # Dynamic access to servers to allow lambda evaluation with request context
+      def servers
+        OasRails.config.servers(@request)
       end
 
       def build(route_extractor: Extractors::RouteExtractor)

--- a/lib/oas_rails/spec/specification.rb
+++ b/lib/oas_rails/spec/specification.rb
@@ -30,7 +30,7 @@ module OasRails
       #
       # @return [void]
       def clear_cache
-        MethodSource.clear_cache
+        # MethodSource.clear_cache # is not available in Ruby 2.7
         Extractors::RouteExtractor.clear_cache
       end
 

--- a/lib/oas_rails/utils.rb
+++ b/lib/oas_rails/utils.rb
@@ -27,7 +27,7 @@ module OasRails
       # Method for detect test framework of the Rails App
       # It is used for generate examples in operations
       def detect_test_framework
-        if defined?(FactoryBot)
+        if defined?(FactoryBot) && FactoryBot.respond_to?(:factories)
           :factory_bot
         elsif ActiveRecord::Base.connection.table_exists?('ar_internal_metadata')
           :fixtures

--- a/lib/oas_rails/yard/oas_rails_factory.rb
+++ b/lib/oas_rails/yard/oas_rails_factory.rb
@@ -7,7 +7,7 @@ module OasRails
       # @return [RequestBodyTag] The parsed request body tag object.
       def parse_tag_with_request_body(tag_name, text)
         description, klass, schema, required = extract_description_and_schema(text.squish)
-        RequestBodyTag.new(tag_name, description, klass, schema:, required:)
+        RequestBodyTag.new(tag_name, description, klass, schema: schema, required: required)
       end
 
       # Parses a tag that represents a request body example.
@@ -26,7 +26,7 @@ module OasRails
       def parse_tag_with_parameter(tag_name, text)
         name, location, schema, required, description = extract_name_location_schema_and_description(text.squish)
         name = "#{name}[]" if location == "query" && schema[:type] == "array"
-        ParameterTag.new(tag_name, name, description, schema, location, required:)
+        ParameterTag.new(tag_name, name, description, schema, location, required: required)
       end
 
       # Parses a tag that represents a response.
@@ -44,7 +44,7 @@ module OasRails
       # @return [ResponseExampleTag] The parsed response example tag object.
       def parse_tag_with_response_example(tag_name, text)
         description, code, hash = extract_name_code_and_hash(text.squish)
-        ResponseExampleTag.new(tag_name, description, content: hash, code:)
+        ResponseExampleTag.new(tag_name, description, content: hash, code: code)
       end
 
       private
@@ -155,7 +155,7 @@ module OasRails
 
         if Utils.active_record_class?(type_text)
           klass = type_text.constantize
-          schema = Builders::EsquemaBuilder.build_outgoing_schema(klass:)
+          schema = Builders::EsquemaBuilder.build_outgoing_schema(klass: klass)
         else
           schema = JsonSchemaGenerator.process_string(type_text)[:json_schema]
           klass = Object

--- a/lib/oas_rails/yard/response_example_tag.rb
+++ b/lib/oas_rails/yard/response_example_tag.rb
@@ -4,7 +4,7 @@ module OasRails
       attr_accessor :code
 
       def initialize(tag_name, text, content: {}, code: 200)
-        super(tag_name, text, content:)
+        super(tag_name, text, content: content)
         @code = code
       end
     end

--- a/oas_rails.gemspec
+++ b/oas_rails.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |spec|
     Dir['{app,config,db,lib,public}/**/*', 'LICENSE', 'Rakefile', 'README.md']
   end
 
-  spec.required_ruby_version = ">= 3.1"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.add_dependency 'easy_talk_two', '~> 1.1.2'
   spec.add_dependency 'method_source', '~> 1.0'

--- a/public/oas-rails-assets/rapidoc-min.js
+++ b/public/oas-rails-assets/rapidoc-min.js
@@ -2800,7 +2800,7 @@ pre[class*="language-"] {
     </nav>`}
 </nav>
 `}function IF(e){const t=new Xe.Renderer;return t.heading=(t,r,s,n)=>`<h${r} class="observe-me" id="${e}--${n.slug(s)}">${t}</h${r}>`,t}function _F(e){return J`
-    <div class='regular-font' part="section-operations-in-tag">
+    <div class='regular-font section-gap--focused-mode' part="section-operations-in-tag">
       ${e}
     </div>`}function RF(){var e;if("true"===this.showInfo)return _F(EF.call(this));const t=this.resolvedSpec.tags[0],r=null===(e=this.resolvedSpec.tags[0])||void 0===e?void 0:e.paths[0];return _F(t&&r?vF.call(this,r,t.name):"")}function FF(e){return J`
     <h1 id="${e.elementId}">${e.displayName||e.name}</h1>

--- a/public/oas-rails-assets/rapidoc-min.js
+++ b/public/oas-rails-assets/rapidoc-min.js
@@ -1078,7 +1078,6 @@ pre[class*="language-"] {
 #api-info {
   font-size: calc(var(--font-size-regular) - 1px);
   margin-top: 8px;
-  margin-left: -15px;
 }
 
 #api-info span:before {

--- a/public/oas-rails-assets/rapidoc-min.js
+++ b/public/oas-rails-assets/rapidoc-min.js
@@ -2800,7 +2800,7 @@ pre[class*="language-"] {
     </nav>`}
 </nav>
 `}function IF(e){const t=new Xe.Renderer;return t.heading=(t,r,s,n)=>`<h${r} class="observe-me" id="${e}--${n.slug(s)}">${t}</h${r}>`,t}function _F(e){return J`
-    <div class='regular-font section-gap--focused-mode' part="section-operations-in-tag">
+    <div class='regular-font' part="section-operations-in-tag">
       ${e}
     </div>`}function RF(){var e;if("true"===this.showInfo)return _F(EF.call(this));const t=this.resolvedSpec.tags[0],r=null===(e=this.resolvedSpec.tags[0])||void 0===e?void 0:e.paths[0];return _F(t&&r?vF.call(this,r,t.name):"")}function FF(e){return J`
     <h1 id="${e.elementId}">${e.displayName||e.name}</h1>

--- a/public/oas-rails-assets/rapidoc-min.js
+++ b/public/oas-rails-assets/rapidoc-min.js
@@ -2579,8 +2579,8 @@ pre[class*="language-"] {
             ${this.resolvedSpec.info.termsOfService?J`<span><a href="${this.resolvedSpec.info.termsOfService}" part="anchor anchor-overview">Terms of Service</a></span>`:""}
             ${this.specUrl&&"true"===this.allowSpecFileDownload?J`
                 <div style="display:flex; margin:12px 0; gap:8px; justify-content: start;">
-                  <button class="m-btn thin-border" style="min-width:170px" part="btn btn-outline" @click='${e=>{gt(this.specUrl,"openapi-spec")}}'>Download OpenAPI spec</button>
-                  ${null!==(s=this.specUrl)&&void 0!==s&&s.trim().toLowerCase().endsWith("json")?J`<button class="m-btn thin-border" style="width:200px" part="btn btn-outline" @click='${e=>{yt(this.specUrl)}}'>View OpenAPI spec (New Tab)</button>`:""}
+                  <button class="m-btn thin-border" style="min-width: 280px !important" part="btn btn-outline" @click='${e=>{gt(this.specUrl,"openapi-spec")}}'>Download OpenAPI spec</button>
+                  ${null!==(s=this.specUrl)&&void 0!==s&&s.trim().toLowerCase().endsWith("json")?J`<button class="m-btn thin-border" style="min-width:280px !important" part="btn btn-outline" @click='${e=>{yt(this.specUrl)}}'>View OpenAPI spec (New Tab)</button>`:""}
                 </div>`:""}
           </div>
           <slot name="overview"></slot>

--- a/test/dummy/app/assets/images/favicon.png
+++ b/test/dummy/app/assets/images/favicon.png
@@ -1,0 +1,1 @@
+fake favicon content

--- a/test/dummy/config/initializers/oas_rails.rb
+++ b/test/dummy/config/initializers/oas_rails.rb
@@ -1,5 +1,6 @@
 OasRails.configure do |config|
   config.info.title = 'Dummy API REST'
+  config.info.version = '1.0.0'
   config.info.summary = 'Core endpoints of Dummy App.'
   config.info.description = <<~HEREDOC
     # Adimuntque regni fuerit
@@ -26,6 +27,10 @@ OasRails.configure do |config|
   config.info.contact.name = 'Peter'
   config.info.contact.email = 'peter@gmail.com'
   config.info.contact.url = 'https://peter.com'
+
+  # Example favicon configuration - uncomment to test
+  # config.info.favicon = '/favicon.ico'  # Static file in public/
+
   config.servers = [{ url: 'http://localhost:3000', description: 'Local' },
                     { url: 'https://example.rb', description: 'Dev' }]
   config.tags = [{ name: "Users", description: "Manage the `amazing` Users table." }]

--- a/test/helpers/oas_rails_application_helper_test.rb
+++ b/test/helpers/oas_rails_application_helper_test.rb
@@ -1,0 +1,78 @@
+require 'test_helper'
+
+class OasRails::ApplicationHelperTest < ActionView::TestCase
+  include OasRails::ApplicationHelper
+
+  def test_favicon_link_tag_for_oas_rails_returns_nil_when_no_favicon_configured
+    OasRails.config.info.favicon = nil
+    assert_nil favicon_link_tag_for_oas_rails
+  end
+
+  def test_favicon_link_tag_for_oas_rails_returns_nil_when_favicon_is_blank
+    OasRails.config.info.favicon = ''
+    assert_nil favicon_link_tag_for_oas_rails
+  end
+
+  def test_favicon_link_tag_for_oas_rails_with_static_path
+    OasRails.config.info.favicon = '/favicon.ico'
+    result = favicon_link_tag_for_oas_rails
+    assert_includes result, '/favicon.ico'
+    assert_includes result, '<link'
+    assert_includes result, 'rel="icon"'
+  end
+
+  def test_favicon_link_tag_for_oas_rails_with_full_url
+    OasRails.config.info.favicon = 'https://example.com/favicon.ico'
+    result = favicon_link_tag_for_oas_rails
+    assert_includes result, 'https://example.com/favicon.ico'
+    assert_includes result, '<link'
+    assert_includes result, 'rel="icon"'
+  end
+
+  def test_resolve_favicon_path_with_full_url
+    result = resolve_favicon_path('https://example.com/favicon.ico')
+    assert_equal 'https://example.com/favicon.ico', result
+  end
+
+  def test_resolve_favicon_path_with_http_url
+    result = resolve_favicon_path('http://example.com/favicon.ico')
+    assert_equal 'http://example.com/favicon.ico', result
+  end
+
+  def test_resolve_favicon_path_with_static_path
+    result = resolve_favicon_path('/favicon.ico')
+    assert_equal '/favicon.ico', result
+  end
+
+  def test_resolve_favicon_path_with_blank_input
+    assert_nil resolve_favicon_path('')
+    assert_nil resolve_favicon_path(nil)
+  end
+
+  def test_resolve_favicon_path_with_asset_pipeline
+    # Mock the image_path method which is what we now use
+    def image_path(asset)
+      "/images/#{asset}"
+    end
+
+    result = resolve_favicon_path('favicon.ico')
+    assert_equal '/images/favicon.ico', result
+  end
+
+  def test_favicon_partial_renders_correctly
+    OasRails.config.info.favicon = '/test-favicon.ico'
+
+    # Test that the partial can be rendered without errors
+    result = render 'oas_rails/shared/favicon'
+    assert_includes result, '<link'
+    assert_includes result, 'rel="icon"'
+    assert_includes result, '/test-favicon.ico'
+  end
+
+  private
+
+  # Make resolve_favicon_path public for testing
+  def resolve_favicon_path(favicon)
+    super
+  end
+end

--- a/test/integration/favicon_integration_test.rb
+++ b/test/integration/favicon_integration_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+class FaviconIntegrationTest < ActionDispatch::IntegrationTest
+  def setup
+    # Reset favicon configuration before each test
+    OasRails.config.info.favicon = nil
+  end
+
+  def teardown
+    # Reset favicon configuration after each test
+    OasRails.config.info.favicon = nil
+  end
+
+  test "favicon link tag is not rendered when no favicon is configured" do
+    get "/docs"
+    assert_response :success
+    assert_select "link[rel='icon']", count: 0
+  end
+
+  test "favicon link tag is rendered with static path" do
+    OasRails.config.info.favicon = "/test-favicon.ico"
+    get "/docs"
+    assert_response :success
+    assert_select "link[rel='icon'][href='/test-favicon.ico']"
+  end
+
+  test "favicon link tag is rendered with full URL" do
+    OasRails.config.info.favicon = "https://example.com/favicon.ico"
+    get "/docs"
+    assert_response :success
+    assert_select "link[rel='icon'][href='https://example.com/favicon.ico']"
+  end
+
+  test "favicon link tag is rendered with asset pipeline asset" do
+    OasRails.config.info.favicon = "favicon.png"
+    get "/docs"
+    assert_response :success
+    # The exact path will depend on asset pipeline, but should include the asset
+    assert_select "link[rel='icon']" do |elements|
+      href = elements.first['href']
+      # Check that it's an asset pipeline path and includes the favicon name
+      assert href.include?('favicon'), "Expected favicon path to include 'favicon', got: #{href}"
+      assert href.include?('.png'), "Expected favicon path to include '.png', got: #{href}"
+      assert href.start_with?('/assets/'), "Expected favicon path to start with '/assets/', got: #{href}"
+    end
+  end
+end

--- a/test/lib/oas_rails/configuration_test.rb
+++ b/test/lib/oas_rails/configuration_test.rb
@@ -1,4 +1,5 @@
 require "test_helper"
+require "ostruct"
 
 module OasRails
   class ConfigurationTest < ActiveSupport::TestCase
@@ -19,12 +20,205 @@ module OasRails
       assert_equal :all, @config.include_mode
     end
 
-    test "sets and gets servers" do
+    test "sets and gets servers with array" do
       servers = [{ url: "https://example.com", description: "Example Server" }]
       @config.servers = servers
       assert_equal 1, @config.servers.size
       assert_equal "https://example.com", @config.servers.first.url
       assert_equal "Example Server", @config.servers.first.description
+    end
+
+    test "sets and gets servers with proc/lambda" do
+      servers_proc = -> { [{ url: "https://dynamic.com", description: "Dynamic Server" }] }
+      @config.servers = servers_proc
+
+      result = @config.servers
+      assert_equal 1, result.size
+      assert_equal "https://dynamic.com", result.first.url
+      assert_equal "Dynamic Server", result.first.description
+    end
+
+    test "servers proc can access runtime variables" do
+      Rails.stub(:env, ActiveSupport::StringInquirer.new("production")) do
+        servers_proc = lambda {
+          if Rails.env.production?
+            [{ url: "https://api.production.com", description: "Production Server" }]
+          else
+            [{ url: "http://localhost:3000", description: "Development Server" }]
+          end
+        }
+        @config.servers = servers_proc
+
+        result = @config.servers
+        assert_equal 1, result.size
+        assert_equal "https://api.production.com", result.first.url
+        assert_equal "Production Server", result.first.description
+      end
+    end
+
+    test "servers proc with development environment" do
+      Rails.stub(:env, ActiveSupport::StringInquirer.new("development")) do
+        servers_proc = lambda {
+          if Rails.env.production?
+            [{ url: "https://api.production.com", description: "Production Server" }]
+          else
+            [{ url: "http://localhost:3000", description: "Development Server" }]
+          end
+        }
+        @config.servers = servers_proc
+
+        result = @config.servers
+        assert_equal 1, result.size
+        assert_equal "http://localhost:3000", result.first.url
+        assert_equal "Development Server", result.first.description
+      end
+    end
+
+    test "servers proc with request parameter" do
+      # Create a mock request object
+      request = OpenStruct.new(
+        host: "api.example.com",
+        subdomain: "staging",
+        headers: { "X-Environment" => "staging" }
+      )
+
+      servers_proc = lambda { |req|
+        if req && req.host == "api.example.com"
+          [{ url: "https://#{req.host}", description: "Dynamic Host Server" }]
+        else
+          [{ url: "http://localhost:3000", description: "Default Server" }]
+        end
+      }
+      @config.servers = servers_proc
+
+      result = @config.servers(request)
+      assert_equal 1, result.size
+      assert_equal "https://api.example.com", result.first.url
+      assert_equal "Dynamic Host Server", result.first.description
+    end
+
+    test "servers proc with request subdomain routing" do
+      request = OpenStruct.new(
+        subdomain: "tenant1",
+        host: "myapp.com"
+      )
+
+      servers_proc = lambda { |req|
+        if req && req.subdomain.present?
+          [{ url: "https://#{req.subdomain}.api.#{req.host}", description: "Tenant API" }]
+        else
+          [{ url: "https://api.#{req&.host || 'localhost:3000'}", description: "Main API" }]
+        end
+      }
+      @config.servers = servers_proc
+
+      result = @config.servers(request)
+      assert_equal 1, result.size
+      assert_equal "https://tenant1.api.myapp.com", result.first.url
+      assert_equal "Tenant API", result.first.description
+    end
+
+    test "servers proc without request parameter (backward compatibility)" do
+      servers_proc = lambda {
+        [{ url: "https://no-request.com", description: "No Request Server" }]
+      }
+      @config.servers = servers_proc
+
+      # Should work with both nil request and no request parameter
+      result1 = @config.servers(nil)
+      assert_equal "https://no-request.com", result1.first.url
+
+      result2 = @config.servers
+      assert_equal "https://no-request.com", result2.first.url
+    end
+
+    test "servers proc can return multiple servers" do
+      servers_proc = lambda {
+        [
+          { url: "https://api.example.com", description: "Production API" },
+          { url: "https://staging.example.com", description: "Staging API" },
+          { url: "http://localhost:3000", description: "Local Development" }
+        ]
+      }
+      @config.servers = servers_proc
+
+      result = @config.servers
+      assert_equal 3, result.size
+      assert_equal "https://api.example.com", result[0].url
+      assert_equal "https://staging.example.com", result[1].url
+      assert_equal "http://localhost:3000", result[2].url
+    end
+
+    test "servers proc can return multiple servers based on request" do
+      request = OpenStruct.new(
+        headers: { "X-Multi-Region" => "true" }
+      )
+
+      servers_proc = lambda { |req|
+        if req && req.headers["X-Multi-Region"] == "true"
+          [
+            { url: "https://us-east.api.com", description: "US East API" },
+            { url: "https://us-west.api.com", description: "US West API" },
+            { url: "https://eu.api.com", description: "EU API" }
+          ]
+        else
+          [{ url: "https://single.api.com", description: "Single API" }]
+        end
+      }
+      @config.servers = servers_proc
+
+      result = @config.servers(request)
+      assert_equal 3, result.size
+      assert_equal "https://us-east.api.com", result[0].url
+      assert_equal "https://us-west.api.com", result[1].url
+      assert_equal "https://eu.api.com", result[2].url
+    end
+
+    test "servers proc that returns invalid data raises error" do
+      servers_proc = -> { "invalid" }
+      @config.servers = servers_proc
+
+      assert_raises(ArgumentError, "servers proc must return an Array") do
+        @config.servers
+      end
+    end
+
+    test "servers with invalid type raises error" do
+      assert_raises(ArgumentError, "servers must be an Array or a Proc") do
+        @config.servers = "invalid"
+      end
+
+      assert_raises(ArgumentError, "servers must be an Array or a Proc") do
+        @config.servers = { url: "test" }
+      end
+    end
+
+    test "servers defaults to default_servers when no static or proc set" do
+      # Reset both to nil to test fallback
+      @config.instance_variable_set(:@servers_static, nil)
+      @config.instance_variable_set(:@servers_proc, nil)
+
+      result = @config.servers
+      assert_equal 1, result.size
+      assert_equal "http://localhost:3000", result.first.url
+      assert_equal "Rails Default Development Server", result.first.description
+    end
+
+    test "switching between array and proc configurations" do
+      # Start with array
+      @config.servers = [{ url: "https://array.com", description: "Array Server" }]
+      result = @config.servers
+      assert_equal "https://array.com", result.first.url
+
+      # Switch to proc
+      @config.servers = -> { [{ url: "https://proc.com", description: "Proc Server" }] }
+      result = @config.servers
+      assert_equal "https://proc.com", result.first.url
+
+      # Switch back to array
+      @config.servers = [{ url: "https://array2.com", description: "Array Server 2" }]
+      result = @config.servers
+      assert_equal "https://array2.com", result.first.url
     end
 
     test "sets and gets tags" do
@@ -58,7 +252,7 @@ module OasRails
       assert_empty @config.security_schemas
     end
 
-    test "dynamic response_body_of_<error> setters and getters" do
+    test "dynamic response_body_of_<e> setters and getters" do
       @config.response_body_of_not_found = "String"
       assert_equal "String", @config.response_body_of_not_found
 
@@ -67,7 +261,7 @@ module OasRails
       assert_raises(ArgumentError) { @config.response_body_of_forbidden = 123 }
     end
 
-    test "all dynamic response_body_of_<error> methods are defined" do
+    test "all dynamic response_body_of_<e> methods are defined" do
       @config.possible_default_responses.each do |response|
         assert_respond_to @config, "response_body_of_#{response}="
         assert_respond_to @config, "response_body_of_#{response}"

--- a/test/lib/oas_rails/configuration_test.rb
+++ b/test/lib/oas_rails/configuration_test.rb
@@ -206,7 +206,7 @@ module OasRails
       assert_equal "https://{defaultHost}", result.last.url
       assert_equal "Dynamic Server (enter your host)", result.last.description
       assert_not_nil result.last.variables
-      assert_equal "api.deployhq.com", result.last.variables[:defaultHost].default
+      assert_equal "api.domain.com", result.last.variables[:defaultHost].default
     end
 
     test "switching between array and proc configurations" do
@@ -299,6 +299,22 @@ module OasRails
       assert_equal "staging", server.variables[:environment].default
       assert_equal %w[staging production], server.variables[:environment].enum
       assert_equal "API environment", server.variables[:environment].description
+    end
+
+    test "info initialize accepts favicon parameter" do
+      info = OasRails::Spec::Info.new(favicon: 'custom-favicon.ico')
+      assert_equal 'custom-favicon.ico', info.favicon
+    end
+
+    test "info favicon defaults to nil" do
+      info = OasRails::Spec::Info.new
+      assert_nil info.favicon
+    end
+
+    test "info favicon can be set after initialization" do
+      info = OasRails::Spec::Info.new
+      info.favicon = '/path/to/favicon.png'
+      assert_equal '/path/to/favicon.png', info.favicon
     end
   end
 end

--- a/test/lib/oas_rails/spec/specification_test.rb
+++ b/test/lib/oas_rails/spec/specification_test.rb
@@ -1,0 +1,126 @@
+require "test_helper"
+require "ostruct"
+
+module OasRails
+  module Spec
+    class SpecificationTest < ActiveSupport::TestCase
+      def setup
+        @original_config = OasRails.config.dup
+      end
+
+      def teardown
+        # Restore original configuration if needed
+      end
+
+      test "specification uses static servers configuration" do
+        OasRails.config.servers = [
+          { url: "https://api.example.com", description: "Production Server" },
+          { url: "http://localhost:3000", description: "Development Server" }
+        ]
+
+        spec = Specification.new
+        assert_equal 2, spec.servers.size
+        assert_equal "https://api.example.com", spec.servers.first.url
+        assert_equal "Production Server", spec.servers.first.description
+      end
+
+      test "specification uses dynamic servers configuration" do
+        OasRails.config.servers = lambda {
+          [{ url: "https://dynamic.example.com", description: "Dynamic Server" }]
+        }
+
+        spec = Specification.new
+        assert_equal 1, spec.servers.size
+        assert_equal "https://dynamic.example.com", spec.servers.first.url
+        assert_equal "Dynamic Server", spec.servers.first.description
+      end
+
+      test "specification handles environment-based dynamic servers" do
+        Rails.stub(:env, ActiveSupport::StringInquirer.new("production")) do
+          OasRails.config.servers = lambda {
+            if Rails.env.production?
+              [{ url: "https://api.production.com", description: "Production API" }]
+            else
+              [{ url: "http://localhost:3000", description: "Development API" }]
+            end
+          }
+
+          spec = Specification.new
+          assert_equal 1, spec.servers.size
+          assert_equal "https://api.production.com", spec.servers.first.url
+          assert_equal "Production API", spec.servers.first.description
+        end
+      end
+
+      test "specification re-evaluates lambda on each access" do
+        counter = 0
+        OasRails.config.servers = lambda {
+          counter += 1
+          [{ url: "https://api#{counter}.example.com", description: "Server #{counter}" }]
+        }
+
+        spec = Specification.new
+
+        # First access
+        servers1 = spec.servers
+        assert_equal "https://api1.example.com", servers1.first.url
+
+        # Second access should re-evaluate the lambda
+        servers2 = spec.servers
+        assert_equal "https://api2.example.com", servers2.first.url
+
+        # Third access
+        servers3 = spec.servers
+        assert_equal "https://api3.example.com", servers3.first.url
+      end
+
+      test "specification passes request to servers lambda" do
+        request = OpenStruct.new(
+          host: "tenant.example.com",
+          subdomain: "tenant"
+        )
+
+        OasRails.config.servers = lambda { |req|
+          if req && req.host.start_with?("tenant")
+            [{ url: "https://api.#{req.host}", description: "Tenant API" }]
+          else
+            [{ url: "http://localhost:3000", description: "Default API" }]
+          end
+        }
+
+        spec = Specification.new(request: request)
+        servers = spec.servers
+        assert_equal 1, servers.size
+        assert_equal "https://api.tenant.example.com", servers.first.url
+        assert_equal "Tenant API", servers.first.description
+      end
+
+      test "specification works without request when lambda doesn't require it" do
+        OasRails.config.servers = lambda {
+          [{ url: "https://static.example.com", description: "Static Server" }]
+        }
+
+        spec = Specification.new
+        servers = spec.servers
+        assert_equal 1, servers.size
+        assert_equal "https://static.example.com", servers.first.url
+      end
+
+      test "specification with request-aware lambda and nil request" do
+        OasRails.config.servers = lambda { |req|
+          if req
+            [{ url: "https://#{req.host}", description: "Dynamic Server" }]
+          else
+            [{ url: "http://localhost:3000", description: "Default Server" }]
+          end
+        }
+
+        spec = Specification.new(request: nil)
+        servers = spec.servers
+        assert_equal 1, servers.size
+        assert_equal "http://localhost:3000", servers.first.url
+        assert_equal "Default Server", servers.first.description
+      end
+    end
+  end
+end


### PR DESCRIPTION
**Chores:**

- Support for Ruby 2.7
- Integration with AR `to_api_hash` (DHQ)

**Features:**

- Dynamic server configuration
- Server variables
- Support for dynamic schema evaluation in the form of `Klass.klass_method`
- Customizable favicon

**Fixes:**

- Button sizes on rapidoc
- Layout changes between `/docs` and `/docs#overview`